### PR TITLE
Fix an inverted Berry check

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,10 +3,8 @@
 * Large Pokémon animations have backwards tiles in the stats screen
 * Caught Pokémon sent to the PC appear at level 255
 * Some caught Pokémon have wrong held items
-* Dark types are not immune to moves whose priority was increased by Prankster
 * In-battle item use messages show the wrong Pokémon name
 * Some NPC trainers use wrong items
-* Held Berries don't always disappear when used
 * Weather and some ability animations trigger the last used animation too
 * TMs refresh PP
 * Nuzlocke mode sometimes turns on by itself (maybe)

--- a/TODO.md
+++ b/TODO.md
@@ -147,7 +147,6 @@ Out-of-battle effects:
 * U-turn switches out
 * Volt Switch switches out
 * Sucker Punch fails if foe is not attacking
-* Thief should either fail when wild Pokémon use it, or only apply during battle
 * Low Kick's power is based on weight
 * Body Slam does double damage against Minimize
 * Stomp and Body Slam never miss against Minimize

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -283,7 +283,7 @@ ConsumeUserItem::
 	pop de
 	ld a, [wItemAttributeParamBuffer]
 	cp BERRIES
-	jr z, .apply_unburden
+	jr nz, .apply_unburden
 	call GetBackupItemAddr
 
 	; If the backup is different, don't touch it. This prevents consuming i.e. Focus Sash


### PR DESCRIPTION
Now Berries are consumed and Sash/etc isn't